### PR TITLE
Field node methods made public for external bit manipulation.

### DIFF
--- a/src/peakrdl_halcpp/include/field_node.h
+++ b/src/peakrdl_halcpp/include/field_node.h
@@ -29,15 +29,11 @@ namespace halcpp
          */
         static constexpr uint32_t get_abs_addr() { return PARENT_TYPE().get_abs_addr(); }
 
-    protected:
-        using parent_type = PARENT_TYPE;
-
-        static constexpr uint32_t start_bit = START_BIT;
-        static constexpr uint32_t end_bit = END_BIT;
-        static constexpr uint32_t width = END_BIT - START_BIT + 1;
-
-        using dataType = typename std::conditional<width <= 8, uint8_t,
-                                                   typename std::conditional<width <= 16, uint16_t, uint32_t>::type>::type;
+        /**
+         * @brief Return the width of the field noe.
+         *
+         */
+        static constexpr uint32_t get_width() { return width; }
 
         /**
          * @brief Calculate the field mask.
@@ -59,6 +55,18 @@ namespace halcpp
         {
             return (((1u << (width)) - 1));
         }
+
+
+
+    protected:
+        using parent_type = PARENT_TYPE;
+
+        static constexpr uint32_t start_bit = START_BIT;
+        static constexpr uint32_t end_bit = END_BIT;
+        static constexpr uint32_t width = END_BIT - START_BIT + 1;
+
+        using dataType = typename std::conditional<width <= 8, uint8_t,
+                                                   typename std::conditional<width <= 16, uint16_t, uint32_t>::type>::type;
     };
 
     /**


### PR DESCRIPTION
Having fieldnode methods public is practical to do bit manipulation according to field properties.